### PR TITLE
dbeaver/pro#10479 Reuse application launch parameters

### DIFF
--- a/osgi.dependency.processing/pom.xml
+++ b/osgi.dependency.processing/pom.xml
@@ -17,6 +17,7 @@
     </properties>
     <build>
         <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/java</testSourceDirectory>
     </build>
     <dependencies>
         <dependency>
@@ -45,6 +46,18 @@
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit-jupiter-version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/osgi.dependency.processing/src/main/java/com/dbeaver/osgi/dependency/processing/xml/LaunchArgumentsXMLReaderExtension.java
+++ b/osgi.dependency.processing/src/main/java/com/dbeaver/osgi/dependency/processing/xml/LaunchArgumentsXMLReaderExtension.java
@@ -1,13 +1,18 @@
 package com.dbeaver.osgi.dependency.processing.xml;
 
+import com.dbeaver.osgi.dependency.processing.PathsManager;
 import com.dbeaver.osgi.dependency.processing.Result;
 import com.dbeaver.osgi.dependency.processing.util.DependencyGraph;
 
+import javax.xml.stream.events.Comment;
 import javax.xml.stream.events.StartElement;
-
 import javax.xml.stream.events.XMLEvent;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLStreamException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -16,6 +21,9 @@ import java.util.regex.Pattern;
 public class LaunchArgumentsXMLReaderExtension extends XmlReaderExtension {
     // regex to match CLI args
     public static final Pattern CLI_REGEX = Pattern.compile("(?<=\\s|^)-{1,2}\\S*(?:\\s+[^\\s-]\\S*)?");
+    private static final Pattern PARAMETERS_MARKER = Pattern.compile(
+        "dbeaver-launch-parameters\\s*:\\s*([a-zA-Z0-9_.-]+(?:\\s*,\\s*[a-zA-Z0-9_.-]+)*)"
+    );
 
     @Override
     public void resolveStartElement(
@@ -43,7 +51,15 @@ public class LaunchArgumentsXMLReaderExtension extends XmlReaderExtension {
     }
 
     private String[] extractArgs(XMLEventReader reader, String startElement) throws XMLStreamException {
-        // Assuming Result has a method to add VM arguments
+        Path parametersDirectory = PathsManager.INSTANCE.getProjectsFolderPath()
+            .resolve("dbeaver")
+            .resolve("product")
+            .resolve("launch-parameters");
+        return extractArgs(reader, startElement, parametersDirectory);
+    }
+
+    static String[] extractArgs(XMLEventReader reader, String startElement, Path parametersDirectory)
+        throws XMLStreamException {
         StringBuilder args = new StringBuilder();
 
         while (reader.hasNext()) {
@@ -53,6 +69,8 @@ public class LaunchArgumentsXMLReaderExtension extends XmlReaderExtension {
             }
             if (event.isCharacters()) {
                 args.append(event.asCharacters().getData().trim()).append(" ");
+            } else if (event instanceof Comment comment) {
+                appendLaunchParameters(args, comment.getText().trim(), parametersDirectory);
             }
         }
         Matcher matcher = CLI_REGEX.matcher(args);
@@ -63,6 +81,29 @@ public class LaunchArgumentsXMLReaderExtension extends XmlReaderExtension {
             argsList.add(matcher.group());
         }
         return argsList.toArray(new String[0]);
+    }
+
+    private static void appendLaunchParameters(StringBuilder args, String comment, Path parametersDirectory)
+        throws XMLStreamException {
+        Matcher marker = PARAMETERS_MARKER.matcher(comment);
+        if (!marker.matches()) {
+            return;
+        }
+        for (String parameterSet : marker.group(1).split(",")) {
+            String name = parameterSet.trim();
+            Path parameterFile = parametersDirectory.resolve(name + ".ini");
+            try {
+                if (!Files.isRegularFile(parameterFile)) {
+                    throw new XMLStreamException("Unknown launch parameter set '" + name + "': " + parameterFile);
+                }
+                Files.readAllLines(parameterFile, StandardCharsets.UTF_8).stream()
+                    .map(String::trim)
+                    .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                    .forEach(line -> args.append(line).append(' '));
+            } catch (IOException e) {
+                throw new XMLStreamException("Error reading launch parameter set '" + name + "'", e);
+            }
+        }
     }
 }
 

--- a/osgi.dependency.processing/src/test/java/com/dbeaver/osgi/dependency/processing/xml/LaunchArgumentsXMLReaderExtensionTest.java
+++ b/osgi.dependency.processing/src/test/java/com/dbeaver/osgi/dependency/processing/xml/LaunchArgumentsXMLReaderExtensionTest.java
@@ -1,0 +1,77 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dbeaver.osgi.dependency.processing.xml;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LaunchArgumentsXMLReaderExtensionTest {
+    @TempDir
+    Path parametersDirectory;
+
+    @Test
+    void expandsParameterSetsInMarkerOrder() throws Exception {
+        Files.writeString(parametersDirectory.resolve("first.ini"), "-Done=1\n--add-opens=first");
+        Files.writeString(parametersDirectory.resolve("second.ini"), "# ignored\n-Dtwo=2\n");
+        XMLEventReader reader = reader("""
+            <vmArgs>-Xms64m<!-- dbeaver-launch-parameters: first, second -->-Xmx1g</vmArgs>
+            """);
+        reader.nextEvent();
+
+        assertArrayEquals(
+            new String[]{"-Xms64m", "-Done=1", "--add-opens=first", "-Dtwo=2", "-Xmx1g"},
+            LaunchArgumentsXMLReaderExtension.extractArgs(reader, "vmArgs", parametersDirectory)
+        );
+    }
+
+    @Test
+    void ignoresUnrelatedComments() throws Exception {
+        XMLEventReader reader = reader("<vmArgs>-Xms64m<!-- explanation -->-Xmx1g</vmArgs>");
+        reader.nextEvent();
+
+        assertArrayEquals(
+            new String[]{"-Xms64m", "-Xmx1g"},
+            LaunchArgumentsXMLReaderExtension.extractArgs(reader, "vmArgs", parametersDirectory)
+        );
+    }
+
+    @Test
+    void rejectsUnknownParameterSet() throws Exception {
+        XMLEventReader reader = reader("<vmArgs><!-- dbeaver-launch-parameters: missing --></vmArgs>");
+        reader.nextEvent();
+
+        Exception exception = assertThrows(
+            Exception.class,
+            () -> LaunchArgumentsXMLReaderExtension.extractArgs(reader, "vmArgs", parametersDirectory)
+        );
+        assertTrue(exception.getMessage().contains("Unknown launch parameter set 'missing'"));
+    }
+
+    private static XMLEventReader reader(String xml) throws Exception {
+        return XMLInputFactory.newFactory().createXMLEventReader(new StringReader(xml));
+    }
+}


### PR DESCRIPTION
Closes dbeaver/pro#10479

Depends on dbeaver/dbeaver#41977.

## Summary
- teach product XML parsing to expand named launch-parameter markers
- resolve canonical parameter files from the shared DBeaver workspace
- add coverage for ordered sets, unrelated comments, and unknown sets

## Testing
- Maven unit tests: 3 passed

This PR was generated with AI (OpenCode).